### PR TITLE
Point submodule to patches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "llvm-project"]
 	path = llvm-project
-	url = https://github.com/llvm/llvm-project
+	url = https://github.com/alan-j-hu/llvm-project
+        branch = 15.x+nnp+depr

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "llvm-project"]
 	path = llvm-project
 	url = https://github.com/alan-j-hu/llvm-project
-        branch = 15.x+nnp+depr
+        branch = release/15.x+nnp+depr


### PR DESCRIPTION
I apologize for not working on LLVM as much recently. I was busy with other tasks. I think this is the best solution.

I am very reluctant to try to upstream anything with Dune to LLVM, because I think Dune doesn't play along well with multi-language or non-standard projects and I think the other LLVM developers will be annoyed by OCaml-specific tooling. So, it's best to keep a separate repo that points to the LLVM repo (or a fork, as this PR does) with a script that generates the Dune files for opam packaging.