### PR TITLE
llvm.executionengine only use ctypes, not ctypes-foreign

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -133,7 +133,7 @@ create_dune_file     llvm                 llvm                       llvm       
 create_dune_file     llvm.analysis        analysis                   llvm_analysis        analysis_ocaml        "llvm"                            "analysis"
 create_dune_file     llvm.bitreader       bitreader                  llvm_bitreader       bitreader_ocaml       "llvm"                            "bitreader"
 create_dune_file     llvm.bitwriter       bitwriter                  llvm_bitwriter       bitwriter_ocaml       "llvm unix"                       "bitwriter"
-create_dune_file     llvm.executionengine executionengine            llvm_executionengine executionengine_ocaml "llvm llvm.target ctypes.foreign" "executionengine mcjit native"
+create_dune_file     llvm.executionengine executionengine            llvm_executionengine executionengine_ocaml "llvm llvm.target ctypes"         "executionengine mcjit native"
 create_dune_file     llvm.ipo             transforms/ipo             llvm_ipo             ipo_ocaml             "llvm"                            "ipo"
 create_dune_file     llvm.irreader        irreader                   llvm_irreader        irreader_ocaml        "llvm"                            "irreader"
 create_dune_file     llvm.scalar_opts     transforms/scalar_opts     llvm_scalar_opts     scalar_opts_ocaml     "llvm"                            "scalaropts"


### PR DESCRIPTION
cc @alan-j-hu This seems to be wrongly defined in [llvm/bindings/ocaml/llvm/META.llvm.in](https://github.com/llvm/llvm-project/blob/bd077e98e463933e72bbd7bd03c6432d529e710c/llvm/bindings/ocaml/llvm/META.llvm.in#L33), as the package itself only requires `ctypes` but the META file requires `ctypes.foreign` for some unknown reason.

Looking at the commit that introduced it https://github.com/llvm/llvm-project/commit/b1f54ff42f96893591dba930320045c4b54c533b, it looks like it's only there to use the `Foreign` module in the tests.